### PR TITLE
Adjust for Python 3 compatibility

### DIFF
--- a/pysigset.py
+++ b/pysigset.py
@@ -49,7 +49,7 @@ class SIGSET(ctypes.Structure):
     sigset_t container, usable for sigprocmask(2), sigpending(2) etc..
 
     """
-    NWORDS = 1024 / (8 * ctypes.sizeof(ctypes.c_uint))
+    NWORDS = int(1024 / (8 * ctypes.sizeof(ctypes.c_uint)))
 
     def __repr__(self):
         ret = []
@@ -217,13 +217,13 @@ if __name__ == '__main__':
     while not done:
         with suspended_signals(SIGINT, SIGTERM):
             # These three seconds are uninterruptible.
-            print 'uninterruptible'
+            print('uninterruptible')
             sleep(3)
 
         if done:
             break
-        print 'interruptible'
+        print('interruptible')
         sleep(3)
-    print 'done'
+    print('done')
 
 # vim: set ts=8 sw=4 sts=4 et ai tw=79:


### PR DESCRIPTION
Hello,

Pysigset currently doesn't work with Python 3 because of a few nits. This patch fixes that.

regards,

Kevin
